### PR TITLE
Make sure download stats work on Hugging Face, improve metadata

### DIFF
--- a/doclayout_yolo/models/yolov10/model.py
+++ b/doclayout_yolo/models/yolov10/model.py
@@ -4,7 +4,9 @@ from .val import YOLOv10DetectionValidator
 from .predict import YOLOv10DetectionPredictor
 from .train import YOLOv10DetectionTrainer
 
-class YOLOv10(Model):
+from huggingface_hub import PyTorchModelHubMixin
+
+class YOLOv10(Model, PyTorchModelHubMixin, repo_url="https://github.com/opendatalab/DocLayout-YOLO", pipeline_tag="object-detection", license="agpl-3.0"):
 
     def __init__(self, model="yolov10n.pt", task=None, verbose=False):
         super().__init__(model=model, task=task, verbose=verbose)


### PR DESCRIPTION
Hi @wangbinDL,

Thanks for this nice work, great to see the models being released on the hub! Your paper was featured on the daily papers: https://huggingface.co/papers/2410.12628. Would be great to link the models to the paper.

To make download stats work, I wrote a PR similar to https://github.com/THU-MIG/yolov10/pull/168 which I did for the YOLOv10 repository.

It leverages the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) developed by the 🤗 team to make sure a custom PyTorch model like yours:
- automatically inherits `from_pretrained` and `push_to_hub` methods
- have better metadata
- make sure download stats work.

Usage is as follows:

```python
from doclayout_yolo import YOLOv10
from huggingface_hub import hf_hub_download

# Load a pre-trained model
filepath = hf_hub_download(repo_id="juliozhao/DocLayout-YOLO-D4LA-from_scratch", filename="doclayout_yolo_d4la_imgsz1600_from_scratch.pt")
model = YOLOv10(filepath)

# One can optionally push this to the hub
model.push_to_hub("juliozhao/DocLayout-YOLO-D4LA-from_scratch")

# Can now be reloaded as follows (and will increment download count)
model = YOLOv10.from_pretrained("juliozhao/DocLayout-YOLO-D4LA-from_scratch")
```

Besides that, some more suggestions to improve the HF release:

- one could create a Gradio demo on 🤗 Spaces to showcase what the model can do.
- one can link the datasets to the models (by adding them to the model cards)
- one can link the models/datasets to the paper page (by including this link: https://huggingface.co/papers/2410.12628 in the model/dataset cards)
- the [dataset viewer](https://huggingface.co/docs/hub/en/datasets-viewer) currently doesn't work for your datasets. See here on how to enable them: https://huggingface.co/docs/datasets/image_dataset#object-detection

Let me know whether you need any help!

Kind regards,

Niels from HF